### PR TITLE
Two new features for calculating holidays

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,22 @@ var nd = require('nth-day');
 // Param #1: nth, 1 to 5, 1st, 2nd, 3rd etc. (Number)
 // Param #2: day, 0 = Sun, 1 = Mon, ... 6 = Sat
 // Param #3: date: A string or Date object to find the month and year, day is not used
-
+// Param #4 (optional): The day of the month to start counting from.
+//      It defaults to zero (i.e. counting from the beginning of the month.)
 var date = nd.nthDay(3, 5, '12/1/2015');
 
 // Finds the 3rd (3), Friday (5), in December 2015
 // date is now 12/16/2015, a moment object
+
+
+var anotherDate = nd.nthDay(2, 2, '12/1/2015',
+                      nd.nthDay(1, 5, '12/1/2015'));
+
+// Finds the 2nd Tuesday after the 1st Friday in December 2015
+
+
+var lastSundayInJanuary = nd.nthDay(-1, 0, '1/1/2015')
+
+// Negative indices count backwards from the end of the month
+
 ```

--- a/src/nth-day.js
+++ b/src/nth-day.js
@@ -26,16 +26,34 @@ function dateFromDate(date) {
 }
 
 // nth - value from 1 through 5 for the (say) 4th Friday
+//   Negative numbers count backwards from the end of the month
+//   (For example, the last Friday, or the second to last Sunday)
 // dayOfWeek - 0 through 6 (Sun through Sat)
 // relevantDate - a date as a string or Date object or moment object
 // Returns a moment date
-export function nthDay(nth, dayOfWeek, relevantDate) {
+export function nthDay(nth, dayOfWeek, relevantDate, after) {
   relevantDate = dateFromDate(relevantDate);
   const month = relevantDate.month();
   const year = relevantDate.year();
+  after = after || 0;
+
+  if (nth < 0) {
+    // nth-last day of the month
+    const fourthDay = nthDay(4, dayOfWeek, relevantDate);
+    let occurrences;
+
+    if (fourthDay.add(1, 'week').month() > month) {
+      // It's a month with four of this day of the week
+      occurrences = 4;
+    } else {
+      // It's a month with five of this day of the week
+      occurrences = 5;
+    }
+    return nthDay(occurrences + 1 + nth, dayOfWeek, relevantDate, after);
+  }
 
   let counter = nth - 1;
-  let day = counter * 7 + 1;
+  let day = counter * 7 + 1 + after;
 
   const date = moment([year, month, day]);
   date.subtract(1, 'day');

--- a/test/src/test.nth-day.js
+++ b/test/src/test.nth-day.js
@@ -44,4 +44,38 @@ describe('nth-day', () => {
     assert(actual.isSame(moment([year, month, 31])));
   });
 
+  it('should get Election Day', () => {
+    const electionDays = [
+      { year: 2000, day: 7 },
+      { year: 2004, day: 2 },
+      { year: 2008, day: 4 },
+      { year: 2012, day: 6 },
+      { year: 2016, day: 8 },
+      { year: 2020, day: 3 }
+    ];
+    
+   electionDays.forEach(election => {
+      // The first Tuesday that's after the first Monday in November
+      const monthDate = '11/1/' + election.year;
+      let actual = nthDay(1, 2, monthDate,
+                     nthDay(1, 1, monthDate).date()
+                   );
+      assert(actual.isSame(moment([election.year, 10, election.day])));
+    });
+  });
+
+  it('should get Arbor Day', () => {
+    const arborDays = [
+      { year: 2013, day: 26 },
+      { year: 2014, day: 25 },
+      { year: 2015, day: 24 },
+      { year: 2016, day: 29 },
+      { year: 2017, day: 28 }
+    ];
+    arborDays.forEach(arborDay => {
+      // The last Friday in April
+      let actual = nthDay(-1, 5, '4/1/' + arborDay.year);
+      assert(actual.isSame(moment([arborDay.year, 3, arborDay.day])));
+    });
+  });
 });


### PR DESCRIPTION
Many American holidays aren't strictly set as the nth of a certain weekday in a month, but rather have a few additional factors thrown in. For example:
- Arbor day is the _last_ Friday in April
- Elections are held on the Tuesday right after the first Monday in November. (In other words, the first Tuesday of the month, unless that's the first day of the month, in which case a week later.)

So, I added two new features, to deal with these two cases:
- If the first argument to nthDay is negative, it is treated as counting backwards from the end as opposed to the beginning. (For example, passing -1 gives you the last occurrence of that day in that month. -2 would give you the second to last.)
- nthDay takes an optional fourth parameter, to tell it where to count from. So election day can be computed as `nthDay(1, 2, "1/11/2016", nthDay(1, 1,"1/11/2016" ).date())`. This computes exactly what we want: It finds the day of the month that the first Monday of November is on, then finds the first Tuesday that's after that day. (Complicated, yes, but I don't set when the US holds its elections! This nested function call is exactly what the US legislature decided as to when to hold elections. And of course all this is fully generalizable: If you want the third Tuesday from the fitth of the month, you can write `nthDay(3, 2, "1/11/2016", 5)`.)

Of course, I also implemented tests for both of these features, and added examples of both features to the README.
