### PR TITLE
Don't refuse to install on node later than 4.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "mocha": "^3.0.1"
   },
   "engines": {
-    "node": "4.2.3"
+    "node": ">=4.2.3"
   },
   "homepage": "https://github.com/guyellis/nth-day#readme",
   "keywords": [


### PR DESCRIPTION
```
$ yarn add nth-day
yarn add v0.27.5
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
error nth-day@1.1.3: The engine "node" is incompatible with this module. Expected version "4.2.3".
error Found incompatible module
```